### PR TITLE
Adding Docker support and fixing install.sh

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM httpd:2.4
+
+ENV adminPass=admin
+ENV SSLCountry=US
+ENV SSLState=MD
+ENV SSLLocation=Baltimore
+Env SSLOrg=ModSec
+ENV SSLCN=localhost
+
+RUN apt-get update && apt-get -y install git cron
+RUN cd /opt/ && \
+    mkdir Waf2Py && \ 
+    git clone https://github.com/ITSec-Chile/Waf2Py
+    
+RUN cd /opt/Waf2Py && \
+    chmod +x Install.sh && \
+    ./Install.sh
+
+EXPOSE 62443


### PR DESCRIPTION
Generally, after adding docker support, this still doesn't work as advertised. The install script places everything correctly, but it doesn't seem to be configured correctly as there is nothing responding on 62443.